### PR TITLE
feat: es-hangul 버젼 v2 마이그레이션

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "axios": "^1.8.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.0.0",
-        "es-hangul": "^1.4.5",
+        "es-hangul": "^2.3.2",
         "lodash": "^4.17.21",
         "lucide-react": "^0.483.0",
         "motion": "^12.5.0",
@@ -3992,9 +3992,15 @@
       }
     },
     "node_modules/es-hangul": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/es-hangul/-/es-hangul-1.4.5.tgz",
-      "integrity": "sha512-dEOjL2ADU3M/QEyjkGnw/0fs2P1/rpIApoV/2lQY6clInHXyT+V+AHzg7+02j1ucguyGqk/wjGgX8EJf9YCJ9w=="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-hangul/-/es-hangul-2.3.2.tgz",
+      "integrity": "sha512-NHLgutwE1SqeDFtGdZENJDyJ71zFjVNffMIh6YwGHLmOe9UlWJK/y592hWVMC1ZVAOypyiLdMACmZ0RiL11O1g==",
+      "license": "MIT",
+      "workspaces": [
+        ".",
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.25.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "axios": "^1.8.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.0.0",
-    "es-hangul": "^1.4.5",
+    "es-hangul": "^2.3.2",
     "lodash": "^4.17.21",
     "lucide-react": "^0.483.0",
     "motion": "^12.5.0",

--- a/src/utils/pokemonFilter.ts
+++ b/src/utils/pokemonFilter.ts
@@ -1,6 +1,6 @@
 import pokemonData from "@/data/pokemon_data.json";
 import { PokemonJSONData } from "@/types";
-import { choseongIncludes } from "es-hangul";
+import { getChoseong } from "es-hangul";
 
 type PokemonName = {
   englishName: string;
@@ -13,9 +13,12 @@ export const filterPokemon = (searchQuery: string): PokemonName[] => {
   return Object.entries(pokemonData as PokemonJSONData)
     .filter(([key, value]) => {
       const lowerCaseKey = key.toLowerCase();
+      const choseongValue = getChoseong(value);
+      const choseongQuery = getChoseong(searchQuery);
+
       return (
         value.includes(searchQuery) ||
-        choseongIncludes(value, searchQuery) ||
+        choseongValue.includes(choseongQuery) ||
         lowerCaseKey.includes(lowerCaseQuery)
       );
     })


### PR DESCRIPTION
### 변경 사항
- es-hangul 패키지를 v2로 업그레이드
- `choseongIncludes` 대신 `getChoseong` 함수 사용
- 초성 검색 로직 리팩토링

### 주요 코드 변경
```typescript
// 기존 코드
choseongIncludes(value, searchQuery)

// 새로운 코드
const choseongValue = getChoseong(value);
const choseongQuery = getChoseong(searchQuery);
choseongValue.includes(choseongQuery)